### PR TITLE
fix the golint errors

### DIFF
--- a/example/ex01/myhook.go
+++ b/example/ex01/myhook.go
@@ -8,54 +8,54 @@ import (
 	hookfs "github.com/osrg/hookfs/hookfs"
 )
 
-// implements hookfs.HookContext
+// MyHookContext implements hookfs.HookContext
 type MyHookContext struct {
 	path string
 }
 
-// implements hookfs.Hook
+// MyHook implements hookfs.Hook
 type MyHook struct{}
 
-// implements hookfs.HookWithInit
-func (this *MyHook) Init() error {
+// Init implements hookfs.HookWithInit
+func (h *MyHook) Init() error {
 	log.WithFields(log.Fields{
-		"this": this,
+		"h": h,
 	}).Info("MyInit: initializing")
 	return nil
 }
 
-// implements hookfs.HookOnOpen
-func (this *MyHook) PreOpen(path string, flags uint32) (error, bool, hookfs.HookContext) {
+// PreOpen implements hookfs.HookOnOpen
+func (h *MyHook) PreOpen(path string, flags uint32) (error, bool, hookfs.HookContext) {
 	ctx := MyHookContext{path: path}
 	if probab(5) {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPreOpen: returning EIO")
 		return syscall.EIO, true, ctx
 	}
 	return nil, false, ctx
 }
 
-// implements hookfs.HookOnOpen
-func (this *MyHook) PostOpen(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+// PostOpen implements hookfs.HookOnOpen
+func (h *MyHook) PostOpen(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	if probab(5) {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPostOpen: returning EPERM")
 		return syscall.EPERM, true
 	}
 	return nil, false
 }
 
-// implements hookfs.HookOnRead
-func (this *MyHook) PreRead(path string, length int64, offset int64) ([]byte, error, bool, hookfs.HookContext) {
+// PreRead implements hookfs.HookOnRead
+func (h *MyHook) PreRead(path string, length int64, offset int64) ([]byte, error, bool, hookfs.HookContext) {
 	ctx := MyHookContext{path: path}
 	if probab(3) {
 		sleep := 3 * time.Second
 		log.WithFields(log.Fields{
-			"this":  this,
+			"h":     h,
 			"ctx":   ctx,
 			"sleep": sleep,
 		}).Info("MyPreRead: sleeping")
@@ -64,27 +64,27 @@ func (this *MyHook) PreRead(path string, length int64, offset int64) ([]byte, er
 	return nil, nil, false, ctx
 }
 
-// implements hookfs.HookOnRead
-func (this *MyHook) PostRead(realRetCode int32, realBuf []byte, ctx hookfs.HookContext) ([]byte, error, bool) {
+// PostRead implements hookfs.HookOnRead
+func (h *MyHook) PostRead(realRetCode int32, realBuf []byte, ctx hookfs.HookContext) ([]byte, error, bool) {
 	if probab(70) {
 		buf := []byte("Hello HookFS hooked Data!\n")
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
-			"buf":  buf,
+			"h":   h,
+			"ctx": ctx,
+			"buf": buf,
 		}).Info("MyPostRead: returning injected buffer")
 		return buf, nil, true
 	}
 	return nil, nil, false
 }
 
-// implements hookfs.HookOnWrite
-func (this *MyHook) PreWrite(path string, buf []byte, offset int64) (error, bool, hookfs.HookContext) {
+// PreWrite implements hookfs.HookOnWrite
+func (h *MyHook) PreWrite(path string, buf []byte, offset int64) (error, bool, hookfs.HookContext) {
 	ctx := MyHookContext{path: path}
 	if probab(3) {
 		sleep := 3 * time.Second
 		log.WithFields(log.Fields{
-			"this":  this,
+			"h":     h,
 			"ctx":   ctx,
 			"sleep": sleep,
 		}).Info("MyPreWrite: sleeping")
@@ -93,100 +93,100 @@ func (this *MyHook) PreWrite(path string, buf []byte, offset int64) (error, bool
 	return nil, false, ctx
 }
 
-// implements hookfs.HookOnWrite
-func (this *MyHook) PostWrite(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+// PostWrite implements hookfs.HookOnWrite
+func (h *MyHook) PostWrite(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	if probab(70) {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPostWrite: returning ENOSPC")
 		return syscall.ENOSPC, true
 	}
 	return nil, false
 }
 
-// implements hookfs.HookOnMkdir
-func (this *MyHook) PreMkdir(path string, mode uint32) (error, bool, hookfs.HookContext) {
+// PreMkdir implements hookfs.HookOnMkdir
+func (h *MyHook) PreMkdir(path string, mode uint32) (error, bool, hookfs.HookContext) {
 	ctx := MyHookContext{path: path}
 	if probab(95) {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPreMkdir: returning EACCES")
 		return syscall.EACCES, true, ctx
 	}
 	return nil, false, ctx
 }
 
-// implements hookfs.HookOnMkdir
-func (this *MyHook) PostMkdir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+// PostMkdir implements hookfs.HookOnMkdir
+func (h *MyHook) PostMkdir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	if probab(5) {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPostMkdir: returning EPERM")
 		return syscall.EPERM, true
 	}
 	return nil, false
 }
 
-// implements hookfs.HookOnRmdir
-func (this *MyHook) PreRmdir(path string) (error, bool, hookfs.HookContext) {
+// PreRmdir implements hookfs.HookOnRmdir
+func (h *MyHook) PreRmdir(path string) (error, bool, hookfs.HookContext) {
 	ctx := MyHookContext{path: path}
 	if probab(30) {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPreRmdir: returning EACCES")
 		return syscall.EACCES, true, ctx
 	}
 	return nil, false, ctx
 }
 
-// implements hookfs.HookOnRmdir
-func (this *MyHook) PostRmdir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+// PostRmdir implements hookfs.HookOnRmdir
+func (h *MyHook) PostRmdir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	if probab(30) {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPostRmdir: returning EPERM")
 		return syscall.EPERM, true
 	}
 	return nil, false
 }
 
-// implements hookfs.HookOnOpenDir
-func (this *MyHook) PreOpenDir(path string) (error, bool, hookfs.HookContext) {
+// PreOpenDir implements hookfs.HookOnOpenDir
+func (h *MyHook) PreOpenDir(path string) (error, bool, hookfs.HookContext) {
 	ctx := MyHookContext{path: path}
 	if probab(30) && path != "" {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPreOpenDir: returning EACCES")
 		return syscall.EACCES, true, ctx
 	}
 	return nil, false, ctx
 }
 
-// implements hookfs.HookOnOpenDir
-func (this *MyHook) PostOpenDir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+// PostOpenDir implements hookfs.HookOnOpenDir
+func (h *MyHook) PostOpenDir(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	if probab(30) && ctx.(MyHookContext).path != "" {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPostOpenDir: returning EPERM")
 		return syscall.EPERM, true
 	}
 	return nil, false
 }
 
-// implements hookfs.HookOnFsync
-func (this *MyHook) PreFsync(path string, flags uint32) (error, bool, hookfs.HookContext) {
+// PreFsync implements hookfs.HookOnFsync
+func (h *MyHook) PreFsync(path string, flags uint32) (error, bool, hookfs.HookContext) {
 	ctx := MyHookContext{path: path}
 	if probab(90) && path != "" {
 		sleep := 3 * time.Second
 		log.WithFields(log.Fields{
-			"this":  this,
+			"h":     h,
 			"ctx":   ctx,
 			"sleep": sleep,
 		}).Info("MyPreFsync: sleeping")
@@ -195,12 +195,12 @@ func (this *MyHook) PreFsync(path string, flags uint32) (error, bool, hookfs.Hoo
 	return nil, false, ctx
 }
 
-// implements hookfs.HookOnFsync
-func (this *MyHook) PostFsync(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
+// PostFsync implements hookfs.HookOnFsync
+func (h *MyHook) PostFsync(realRetCode int32, ctx hookfs.HookContext) (error, bool) {
 	if probab(80) && ctx.(MyHookContext).path != "" {
 		log.WithFields(log.Fields{
-			"this": this,
-			"ctx":  ctx,
+			"h":   h,
+			"ctx": ctx,
 		}).Info("MyPostFsync: returning EIO")
 		return syscall.EIO, true
 	}

--- a/hookfs/fs.go
+++ b/hookfs/fs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hanwen/go-fuse/fuse/pathfs"
 )
 
-// HookFS object
+// HookFs is the object hooking the fs.
 type HookFs struct {
 	Original   string
 	Mountpoint string
@@ -19,7 +19,7 @@ type HookFs struct {
 	hook       Hook
 }
 
-// Instantiate a new HookFS object
+// NewHookFs creates a new HookFs object
 func NewHookFs(original string, mountpoint string, hook Hook) (*HookFs, error) {
 	log.WithFields(log.Fields{
 		"original":   original,
@@ -37,55 +37,55 @@ func NewHookFs(original string, mountpoint string, hook Hook) (*HookFs, error) {
 	return hookfs, nil
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) String() string {
+// String implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) String() string {
 	return fmt.Sprintf("HookFs{Original=%s, Mountpoint=%s, FsName=%s, Underlying fs=%s, hook=%s}",
-		this.Original, this.Mountpoint, this.FsName, this.fs.String(), this.hook)
+		h.Original, h.Mountpoint, h.FsName, h.fs.String(), h.hook)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) SetDebug(debug bool) {
-	this.fs.SetDebug(debug)
+// SetDebug implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) SetDebug(debug bool) {
+	h.fs.SetDebug(debug)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) GetAttr(name string, context *fuse.Context) (*fuse.Attr, fuse.Status) {
-	return this.fs.GetAttr(name, context)
+// GetAttr implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) GetAttr(name string, context *fuse.Context) (*fuse.Attr, fuse.Status) {
+	return h.fs.GetAttr(name, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Chmod(name string, mode uint32, context *fuse.Context) fuse.Status {
-	return this.fs.Chmod(name, mode, context)
+// Chmod implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Chmod(name string, mode uint32, context *fuse.Context) fuse.Status {
+	return h.fs.Chmod(name, mode, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Chown(name string, uid uint32, gid uint32, context *fuse.Context) fuse.Status {
-	return this.fs.Chown(name, uid, gid, context)
+// Chown implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Chown(name string, uid uint32, gid uint32, context *fuse.Context) fuse.Status {
+	return h.fs.Chown(name, uid, gid, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Utimens(name string, Atime *time.Time, Mtime *time.Time, context *fuse.Context) fuse.Status {
-	return this.fs.Utimens(name, Atime, Mtime, context)
+// Utimens implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Utimens(name string, Atime *time.Time, Mtime *time.Time, context *fuse.Context) fuse.Status {
+	return h.fs.Utimens(name, Atime, Mtime, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Truncate(name string, size uint64, context *fuse.Context) fuse.Status {
-	return this.fs.Truncate(name, size, context)
+// Truncate implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Truncate(name string, size uint64, context *fuse.Context) fuse.Status {
+	return h.fs.Truncate(name, size, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Access(name string, mode uint32, context *fuse.Context) fuse.Status {
-	return this.fs.Access(name, mode, context)
+// Access implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Access(name string, mode uint32, context *fuse.Context) fuse.Status {
+	return h.fs.Access(name, mode, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Link(oldName string, newName string, context *fuse.Context) fuse.Status {
-	return this.fs.Link(oldName, newName, context)
+// Link implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Link(oldName string, newName string, context *fuse.Context) fuse.Status {
+	return h.fs.Link(oldName, newName, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Mkdir(name string, mode uint32, context *fuse.Context) fuse.Status {
-	hook, hookEnabled := this.hook.(HookOnMkdir)
+// Mkdir implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Mkdir(name string, mode uint32, context *fuse.Context) fuse.Status {
+	hook, hookEnabled := h.hook.(HookOnMkdir)
 	var prehookErr, posthookErr error
 	var prehooked, posthooked bool
 	var prehookCtx HookContext
@@ -94,27 +94,27 @@ func (this *HookFs) Mkdir(name string, mode uint32, context *fuse.Context) fuse.
 		prehookErr, prehooked, prehookCtx = hook.PreMkdir(name, mode)
 		if prehooked {
 			log.WithFields(log.Fields{
-				"this":       this,
+				"h":          h,
 				"prehookErr": prehookErr,
 				"prehookCtx": prehookCtx,
 			}).Debug("Mkdir: Prehooked")
 			if prehookErr == nil {
 				log.WithFields(log.Fields{
-					"this":       this,
+					"h":          h,
 					"prehookErr": prehookErr,
 					"prehookCtx": prehookCtx,
-				}).Fatal("Mkdir is prehooked, but did not returned an error. this is very strange.")
+				}).Fatal("Mkdir is prehooked, but did not returned an error. h is very strange.")
 			}
 			return fuse.ToStatus(prehookErr)
 		}
 	}
 
-	lowerCode := this.fs.Mkdir(name, mode, context)
+	lowerCode := h.fs.Mkdir(name, mode, context)
 	if hookEnabled {
 		posthookErr, posthooked = hook.PostMkdir(int32(lowerCode), prehookCtx)
 		if posthooked {
 			log.WithFields(log.Fields{
-				"this":        this,
+				"h":           h,
 				"posthookErr": posthookErr,
 			}).Debug("Mkdir: Posthooked")
 			return fuse.ToStatus(posthookErr)
@@ -124,19 +124,19 @@ func (this *HookFs) Mkdir(name string, mode uint32, context *fuse.Context) fuse.
 	return lowerCode
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Mknod(name string, mode uint32, dev uint32, context *fuse.Context) fuse.Status {
-	return this.fs.Mknod(name, mode, dev, context)
+// Mknod implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Mknod(name string, mode uint32, dev uint32, context *fuse.Context) fuse.Status {
+	return h.fs.Mknod(name, mode, dev, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Rename(oldName string, newName string, context *fuse.Context) fuse.Status {
-	return this.fs.Rename(oldName, newName, context)
+// Rename implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Rename(oldName string, newName string, context *fuse.Context) fuse.Status {
+	return h.fs.Rename(oldName, newName, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Rmdir(name string, context *fuse.Context) fuse.Status {
-	hook, hookEnabled := this.hook.(HookOnRmdir)
+// Rmdir implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Rmdir(name string, context *fuse.Context) fuse.Status {
+	hook, hookEnabled := h.hook.(HookOnRmdir)
 	var prehookErr, posthookErr error
 	var prehooked, posthooked bool
 	var prehookCtx HookContext
@@ -145,27 +145,27 @@ func (this *HookFs) Rmdir(name string, context *fuse.Context) fuse.Status {
 		prehookErr, prehooked, prehookCtx = hook.PreRmdir(name)
 		if prehooked {
 			log.WithFields(log.Fields{
-				"this":       this,
+				"h":          h,
 				"prehookErr": prehookErr,
 				"prehookCtx": prehookCtx,
 			}).Debug("Rmdir: Prehooked")
 			if prehookErr == nil {
 				log.WithFields(log.Fields{
-					"this":       this,
+					"h":          h,
 					"prehookErr": prehookErr,
 					"prehookCtx": prehookCtx,
-				}).Fatal("Rmdir is prehooked, but did not returned an error. this is very strange.")
+				}).Fatal("Rmdir is prehooked, but did not returned an error. h is very strange.")
 			}
 			return fuse.ToStatus(prehookErr)
 		}
 	}
 
-	lowerCode := this.fs.Rmdir(name, context)
+	lowerCode := h.fs.Rmdir(name, context)
 	if hookEnabled {
 		posthookErr, posthooked = hook.PostRmdir(int32(lowerCode), prehookCtx)
 		if posthooked {
 			log.WithFields(log.Fields{
-				"this":        this,
+				"h":           h,
 				"posthookErr": posthookErr,
 			}).Debug("Mkdir: Posthooked")
 			return fuse.ToStatus(posthookErr)
@@ -175,53 +175,53 @@ func (this *HookFs) Rmdir(name string, context *fuse.Context) fuse.Status {
 	return lowerCode
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Unlink(name string, context *fuse.Context) fuse.Status {
-	return this.fs.Unlink(name, context)
+// Unlink implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Unlink(name string, context *fuse.Context) fuse.Status {
+	return h.fs.Unlink(name, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) GetXAttr(name string, attribute string, context *fuse.Context) ([]byte, fuse.Status) {
-	return this.fs.GetXAttr(name, attribute, context)
+// GetXAttr implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) GetXAttr(name string, attribute string, context *fuse.Context) ([]byte, fuse.Status) {
+	return h.fs.GetXAttr(name, attribute, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) ListXAttr(name string, context *fuse.Context) ([]string, fuse.Status) {
-	return this.fs.ListXAttr(name, context)
+// ListXAttr implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) ListXAttr(name string, context *fuse.Context) ([]string, fuse.Status) {
+	return h.fs.ListXAttr(name, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) RemoveXAttr(name string, attr string, context *fuse.Context) fuse.Status {
-	return this.fs.RemoveXAttr(name, attr, context)
+// RemoveXAttr implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) RemoveXAttr(name string, attr string, context *fuse.Context) fuse.Status {
+	return h.fs.RemoveXAttr(name, attr, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) SetXAttr(name string, attr string, data []byte, flags int, context *fuse.Context) fuse.Status {
-	return this.fs.SetXAttr(name, attr, data, flags, context)
+// SetXAttr implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) SetXAttr(name string, attr string, data []byte, flags int, context *fuse.Context) fuse.Status {
+	return h.fs.SetXAttr(name, attr, data, flags, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) OnMount(nodeFs *pathfs.PathNodeFs) {
-	this.fs.OnMount(nodeFs)
-	hook, hookEnabled := this.hook.(HookWithInit)
+// OnMount implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) OnMount(nodeFs *pathfs.PathNodeFs) {
+	h.fs.OnMount(nodeFs)
+	hook, hookEnabled := h.hook.(HookWithInit)
 	if hookEnabled {
 		err := hook.Init()
 		if err != nil {
 			log.Error(err)
 			log.Warn("Disabling hook")
-			this.hook = nil
+			h.hook = nil
 		}
 	}
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) OnUnmount() {
-	this.fs.OnUnmount()
+// OnUnmount implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) OnUnmount() {
+	h.fs.OnUnmount()
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Open(name string, flags uint32, context *fuse.Context) (nodefs.File, fuse.Status) {
-	hook, hookEnabled := this.hook.(HookOnOpen)
+// Open implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Open(name string, flags uint32, context *fuse.Context) (nodefs.File, fuse.Status) {
+	hook, hookEnabled := h.hook.(HookOnOpen)
 	var prehookErr, posthookErr error
 	var prehooked, posthooked bool
 	var prehookCtx HookContext
@@ -230,23 +230,23 @@ func (this *HookFs) Open(name string, flags uint32, context *fuse.Context) (node
 		prehookErr, prehooked, prehookCtx = hook.PreOpen(name, flags)
 		if prehooked {
 			log.WithFields(log.Fields{
-				"this":       this,
+				"h":          h,
 				"prehookErr": prehookErr,
 				"prehookCtx": prehookCtx,
 			}).Debug("Open: Prehooked")
 			if prehookErr == nil {
 				log.WithFields(log.Fields{
-					"this":       this,
+					"h":          h,
 					"prehookErr": prehookErr,
 					"prehookCtx": prehookCtx,
-				}).Fatal("Open is prehooked, but did not returned an error. this is very strange.")
+				}).Fatal("Open is prehooked, but did not returned an error. h is very strange.")
 			}
 			return nil, fuse.ToStatus(prehookErr)
 		}
 	}
 
-	lowerFile, lowerCode := this.fs.Open(name, flags, context)
-	hFile, hErr := newHookFile(lowerFile, name, this.hook)
+	lowerFile, lowerCode := h.fs.Open(name, flags, context)
+	hFile, hErr := newHookFile(lowerFile, name, h.hook)
 	if hErr != nil {
 		log.WithField("error", hErr).Panic("NewHookFile() should not cause an error")
 	}
@@ -255,7 +255,7 @@ func (this *HookFs) Open(name string, flags uint32, context *fuse.Context) (node
 		posthookErr, posthooked = hook.PostOpen(int32(lowerCode), prehookCtx)
 		if posthooked {
 			log.WithFields(log.Fields{
-				"this":        this,
+				"h":           h,
 				"posthookErr": posthookErr,
 			}).Debug("Open: Posthooked")
 			return hFile, fuse.ToStatus(posthookErr)
@@ -265,19 +265,19 @@ func (this *HookFs) Open(name string, flags uint32, context *fuse.Context) (node
 	return hFile, lowerCode
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Create(name string, flags uint32, mode uint32, context *fuse.Context) (nodefs.File, fuse.Status) {
-	lowerFile, lowerCode := this.fs.Create(name, flags, mode, context)
-	hFile, hErr := newHookFile(lowerFile, name, this.hook)
+// Create implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Create(name string, flags uint32, mode uint32, context *fuse.Context) (nodefs.File, fuse.Status) {
+	lowerFile, lowerCode := h.fs.Create(name, flags, mode, context)
+	hFile, hErr := newHookFile(lowerFile, name, h.hook)
 	if hErr != nil {
 		log.WithField("error", hErr).Panic("NewHookFile() should not cause an error")
 	}
 	return hFile, lowerCode
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) OpenDir(name string, context *fuse.Context) ([]fuse.DirEntry, fuse.Status) {
-	hook, hookEnabled := this.hook.(HookOnOpenDir)
+// OpenDir implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) OpenDir(name string, context *fuse.Context) ([]fuse.DirEntry, fuse.Status) {
+	hook, hookEnabled := h.hook.(HookOnOpenDir)
 	var prehookErr, posthookErr error
 	var prehooked, posthooked bool
 	var prehookCtx HookContext
@@ -286,27 +286,27 @@ func (this *HookFs) OpenDir(name string, context *fuse.Context) ([]fuse.DirEntry
 		prehookErr, prehooked, prehookCtx = hook.PreOpenDir(name)
 		if prehooked {
 			log.WithFields(log.Fields{
-				"this":       this,
+				"h":          h,
 				"prehookErr": prehookErr,
 				"prehookCtx": prehookCtx,
 			}).Debug("OpenDir: Prehooked")
 			if prehookErr == nil {
 				log.WithFields(log.Fields{
-					"this":       this,
+					"h":          h,
 					"prehookErr": prehookErr,
 					"prehookCtx": prehookCtx,
-				}).Fatal("OpenDir is prehooked, but did not returned an error. this is very strange.")
+				}).Fatal("OpenDir is prehooked, but did not returned an error. h is very strange.")
 			}
 			return nil, fuse.ToStatus(prehookErr)
 		}
 	}
 
-	lowerEnts, lowerCode := this.fs.OpenDir(name, context)
+	lowerEnts, lowerCode := h.fs.OpenDir(name, context)
 	if hookEnabled {
 		posthookErr, posthooked = hook.PostOpenDir(int32(lowerCode), prehookCtx)
 		if posthooked {
 			log.WithFields(log.Fields{
-				"this":        this,
+				"h":           h,
 				"posthookErr": posthookErr,
 			}).Debug("OpenDir: Posthooked")
 			return lowerEnts, fuse.ToStatus(posthookErr)
@@ -316,24 +316,24 @@ func (this *HookFs) OpenDir(name string, context *fuse.Context) ([]fuse.DirEntry
 	return lowerEnts, lowerCode
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Symlink(value string, linkName string, context *fuse.Context) fuse.Status {
-	return this.fs.Symlink(value, linkName, context)
+// Symlink implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Symlink(value string, linkName string, context *fuse.Context) fuse.Status {
+	return h.fs.Symlink(value, linkName, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) Readlink(name string, context *fuse.Context) (string, fuse.Status) {
-	return this.fs.Readlink(name, context)
+// Readlink implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) Readlink(name string, context *fuse.Context) (string, fuse.Status) {
+	return h.fs.Readlink(name, context)
 }
 
-// implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call this manually.
-func (this *HookFs) StatFs(name string) *fuse.StatfsOut {
-	return this.fs.StatFs(name)
+// StatFs implements hanwen/go-fuse/fuse/pathfs.FileSystem. You are not expected to call h manually.
+func (h *HookFs) StatFs(name string) *fuse.StatfsOut {
+	return h.fs.StatFs(name)
 }
 
-// Start the server (blocking).
-func (this *HookFs) Serve() error {
-	server, err := newHookServer(this)
+// Serve starts the server (blocking).
+func (h *HookFs) Serve() error {
+	server, err := newHookServer(h)
 	if err != nil {
 		return err
 	}

--- a/hookfs/hook.go
+++ b/hookfs/hook.go
@@ -1,62 +1,61 @@
 package hookfs
 
-// Base interface for user-written hooks.
+// Hook is the base interface for user-written hooks.
 //
 // You have to implement HookXXX (e.g. HookOnOpen, HookOnRead, HookOnWrite, ..) interfaces.
 type Hook interface{}
 
-// Context objects for interaction between prehooks and posthooks.
+// HookContext is the context objects for interaction between prehooks and posthooks.
 type HookContext interface{}
 
-// Called on mount. This also implements Hook.
+// HookWithInit is called on mount. This also implements Hook.
 type HookWithInit interface {
 	Init() (err error)
 }
 
-// Called on open. This also implements Hook.
+// HookOnOpen is called on open. This also implements Hook.
 type HookOnOpen interface {
 	// if hooked is true, the real open() would not be called
 	PreOpen(path string, flags uint32) (err error, hooked bool, ctx HookContext)
 	PostOpen(realRetCode int32, prehookCtx HookContext) (err error, hooked bool)
 }
 
-// Called on read. This also implements Hook.
+// HookOnRead is called on read. This also implements Hook.
 type HookOnRead interface {
 	// if hooked is true, the real read() would not be called
 	PreRead(path string, length int64, offset int64) (buf []byte, err error, hooked bool, ctx HookContext)
 	PostRead(realRetCode int32, realBuf []byte, prehookCtx HookContext) (buf []byte, err error, hooked bool)
 }
 
-// Called on write. This also implements Hook.
-// BUG(AkihiroSuda): HookOnWrite is not yet implemented.
+// HookOnWrite is called on write. This also implements Hook.
 type HookOnWrite interface {
 	// if hooked is true, the real write() would not be called
 	PreWrite(path string, buf []byte, offset int64) (err error, hooked bool, ctx HookContext)
 	PostWrite(realRetCode int32, prehookCtx HookContext) (err error, hooked bool)
 }
 
-// Called on mkdir. This also implements Hook.
+// HookOnMkdir is called on mkdir. This also implements Hook.
 type HookOnMkdir interface {
 	// if hooked is true, the real mkdir() would not be called
 	PreMkdir(path string, mode uint32) (err error, hooked bool, ctx HookContext)
 	PostMkdir(realRetCode int32, prehookCtx HookContext) (err error, hooked bool)
 }
 
-// Called on rmdir. This also implements Hook.
+// HookOnRmdir is called on rmdir. This also implements Hook.
 type HookOnRmdir interface {
 	// if hooked is true, the real rmdir() would not be called
 	PreRmdir(path string) (err error, hooked bool, ctx HookContext)
 	PostRmdir(realRetCode int32, prehookCtx HookContext) (err error, hooked bool)
 }
 
-// Called on opendir. This also implements Hook.
+// HookOnOpenDir is called on opendir. This also implements Hook.
 type HookOnOpenDir interface {
 	// if hooked is true, the real opendir() would not be called
 	PreOpenDir(path string) (err error, hooked bool, ctx HookContext)
 	PostOpenDir(realRetCode int32, prehookCtx HookContext) (err error, hooked bool)
 }
 
-// Called on fsync. This also implements Hook.
+// HookOnFsync is called on fsync. This also implements Hook.
 type HookOnFsync interface {
 	// if hooked is true, the real fsync() would not be called
 	PreFsync(path string, flags uint32) (err error, hooked bool, ctx HookContext)

--- a/hookfs/init.go
+++ b/hookfs/init.go
@@ -1,14 +1,15 @@
 package hookfs
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"os"
+
+	log "github.com/Sirupsen/logrus"
 )
 
-// minimum log level
+// LogLevelMin is the minimum log level
 const LogLevelMin = 0
 
-// maximum log level
+// LogLevelMax is the maximum log level
 const LogLevelMax = 2
 
 var logLevel int
@@ -18,12 +19,12 @@ func initLog() {
 	log.SetOutput(os.Stderr)
 }
 
-// Getter for log level
+// LogLevel gets the log level.
 func LogLevel() int {
 	return logLevel
 }
 
-// Setter for log level. newLevel must be >= LogLevelMin, and <= LogLevelMax.
+// SetLogLevel sets the log level. newLevel must be >= LogLevelMin, and <= LogLevelMax.
 func SetLogLevel(newLevel int) {
 	if newLevel < LogLevelMin || newLevel > LogLevelMax {
 		log.Fatalf("Bad log level: %d (must be %d..%d)", newLevel, LogLevelMin, LogLevelMax)


### PR DESCRIPTION
Golint will throw many warnings and errors, we should improve them to let hookfs follow the Go style.

Improvement:

1. The first word of the comment must be the structure or function name
2. `this` is not a recommended name, use `h` (presents `hook`) instead. 

PTAL @AkihiroSuda 